### PR TITLE
Pricing bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -1194,8 +1194,8 @@ def calculate_session_cost(total_prompt_tokens, total_completion_tokens, pricing
         return 0.0
     
     # Convert to cost per 1000 tokens
-    prompt_cost = (total_prompt_tokens / 1000) * pricing_info['prompt_price']
-    completion_cost = (total_completion_tokens / 1000) * pricing_info['completion_price']
+    prompt_cost = total_prompt_tokens * pricing_info['prompt_price']
+    completion_cost = total_completion_tokens * pricing_info['completion_price']
     
     return prompt_cost + completion_cost
 

--- a/main.py
+++ b/main.py
@@ -1115,8 +1115,9 @@ def get_model_pricing_info(model_name):
                             'provider': endpoint.get('provider_name', 'Unknown')
                         }
                     elif pricing:
-                        prompt_price = float(pricing.get('prompt', '0'))
-                        completion_price = float(pricing.get('completion', '0'))
+                        # Note: this is price per 1k tokens
+                        prompt_price = float(pricing.get('prompt', '0')) * 1000
+                        completion_price = float(pricing.get('completion', '0')) * 1000
                         
                         # Check if the model name explicitly indicates it's free
                         is_explicitly_free = model_name and (model_name.endswith(':free') or ':free' in model_name)
@@ -1143,14 +1144,14 @@ def get_model_pricing_info(model_name):
                         else:
                             # Format prices for display
                             if prompt_price < 0.001:
-                                prompt_display = f"${prompt_price:.6f}"
-                            else:
                                 prompt_display = f"${prompt_price:.4f}"
+                            else:
+                                prompt_display = f"${prompt_price:.3f}"
                                 
                             if completion_price < 0.001:
-                                completion_display = f"${completion_price:.6f}"
-                            else:
                                 completion_display = f"${completion_price:.4f}"
+                            else:
+                                completion_display = f"${completion_price:.3f}"
                                 
                             return {
                                 'is_free': False,


### PR DESCRIPTION
In OpenRouter docs, it's counted per token so no need to divide by 1000.

This also means that we have to multiply by 1000 when doing the price/1k tokens calculation. I also adjusted the decimal places. 